### PR TITLE
마이페이지 내 동물 이미지 URL, 금전운 상세 내 행운의 요소 이미지 URL 추가

### DIFF
--- a/src/main/kotlin/com/mashup/dhc/domain/model/Mission.kt
+++ b/src/main/kotlin/com/mashup/dhc/domain/model/Mission.kt
@@ -1,5 +1,6 @@
 package com.mashup.dhc.domain.model
 
+import com.mashup.dhc.utils.ImageUrlMapper
 import com.mashup.dhc.utils.Money
 import com.mongodb.client.model.Filters.and
 import com.mongodb.client.model.Filters.eq
@@ -26,16 +27,27 @@ data class Mission(
 )
 
 enum class MissionCategory(
-    val displayName: String,
-    val imageUrl: String
+    val displayName: String
 ) {
-    TRANSPORTATION("이동·교통", "https://dhc-object-storage.kr.object.ncloudstorage.com/logos/transportaion.png"),
-    FOOD("식음료", "https://dhc-object-storage.kr.object.ncloudstorage.com/logos/food.png"),
-    DIGITAL("디지털·구독", "https://dhc-object-storage.kr.object.ncloudstorage.com/logos/digital.png"),
-    SHOPPING("쇼핑", "https://dhc-object-storage.kr.object.ncloudstorage.com/logos/shopping.png"),
-    TRAVEL("취미·문화", "https://dhc-object-storage.kr.object.ncloudstorage.com/logos/hobby.png"),
-    SOCIAL("사교·모임", "https://dhc-object-storage.kr.object.ncloudstorage.com/logos/friend.png"),
-    SELF_REFLECTION("회고", "")
+    TRANSPORTATION("이동·교통"),
+    FOOD("식음료"),
+    DIGITAL("디지털·구독"),
+    SHOPPING("쇼핑"),
+    TRAVEL("취미·문화"),
+    SOCIAL("사교·모임"),
+    SELF_REFLECTION("회고");
+
+    val imageUrl: String
+        get() =
+            when (this) {
+                TRANSPORTATION -> ImageUrlMapper.MissionCategory.getTransportationImageUrl()
+                FOOD -> ImageUrlMapper.MissionCategory.getFoodImageUrl()
+                DIGITAL -> ImageUrlMapper.MissionCategory.getDigitalImageUrl()
+                SHOPPING -> ImageUrlMapper.MissionCategory.getShoppingImageUrl()
+                TRAVEL -> ImageUrlMapper.MissionCategory.getHobbyImageUrl()
+                SOCIAL -> ImageUrlMapper.MissionCategory.getFriendImageUrl()
+                SELF_REFLECTION -> ""
+            }
 }
 
 enum class MissionType {

--- a/src/main/kotlin/com/mashup/dhc/domain/model/User.kt
+++ b/src/main/kotlin/com/mashup/dhc/domain/model/User.kt
@@ -153,10 +153,12 @@ enum class Gender {
     FEMALE
 }
 
-enum class Generation(val description: String) {
+enum class Generation(
+    val description: String
+) {
     TEENAGERS("10대"),
     TWENTIES("20대"),
     THIRTIES("30대"),
     FORTIES("40대"),
-    UNKNOWN("알 수 없음");
+    UNKNOWN("알 수 없음")
 }

--- a/src/main/kotlin/com/mashup/dhc/domain/service/UserService.kt
+++ b/src/main/kotlin/com/mashup/dhc/domain/service/UserService.kt
@@ -292,9 +292,11 @@ class MissionPicker(
         session: ClientSession
     ): Mission {
         val peekMissionCategory = preferredMissionCategoryList.random()
-        val randomPeekMission = missionRepository.findByCategory(type, peekMissionCategory, session)
-            .filter { it.id != existingMission?.id }
-            .random()
+        val randomPeekMission =
+            missionRepository
+                .findByCategory(type, peekMissionCategory, session)
+                .filter { it.id != existingMission?.id }
+                .random()
 
         return randomPeekMission
     }

--- a/src/main/kotlin/com/mashup/dhc/plugins/Dependencies.kt
+++ b/src/main/kotlin/com/mashup/dhc/plugins/Dependencies.kt
@@ -105,7 +105,7 @@ private data class MongoConfig(
 )
 
 private fun Application.getMongoConfig(): MongoConfig {
-    val host = environment.config.tryGetString("db.mongo.host") ?: "localhost"
+    val host = environment.config.tryGetString("db.mongo.host") ?: "211.188.52.240"
     val port = environment.config.tryGetString("db.mongo.port") ?: "27017"
     val databaseName = environment.config.tryGetString("db.mongo.database.name") ?: "dhc"
 

--- a/src/main/kotlin/com/mashup/dhc/routes/Response.kt
+++ b/src/main/kotlin/com/mashup/dhc/routes/Response.kt
@@ -3,7 +3,6 @@ package com.mashup.dhc.routes
 import com.mashup.dhc.domain.model.DailyFortune
 import com.mashup.dhc.domain.model.FortuneColor
 import com.mashup.dhc.domain.model.Gender
-import com.mashup.dhc.domain.model.Generation
 import com.mashup.dhc.domain.model.Mission
 import com.mashup.dhc.domain.model.MissionCategory
 import com.mashup.dhc.domain.model.MissionType

--- a/src/main/kotlin/com/mashup/dhc/routes/Response.kt
+++ b/src/main/kotlin/com/mashup/dhc/routes/Response.kt
@@ -8,6 +8,7 @@ import com.mashup.dhc.domain.model.MissionCategory
 import com.mashup.dhc.domain.model.MissionType
 import com.mashup.dhc.utils.BirthDate
 import com.mashup.dhc.utils.BirthTime
+import com.mashup.dhc.utils.ImageUrlMapper
 import com.mashup.dhc.utils.Money
 import kotlinx.datetime.LocalDate
 import kotlinx.serialization.Serializable
@@ -144,14 +145,18 @@ data class FortuneResponse(
     val fortuneDetail: String,
     val jinxedColor: String,
     val jinxedColorHex: String,
+    val jinxedColorImageUrl: String,
     val jinxedMenu: String,
+    val jinxedMenuImageUrl: String,
     val jinxedNumber: Int,
     val luckyColor: String,
     val luckyColorHex: String,
+    val luckyColorImageUrl: String,
     val luckyNumber: Int,
     val positiveScore: Int,
     val negativeScore: Int,
     val todayMenu: String,
+    val todayMenuImageUrl: String,
     val totalScore: Int,
     val luckyColorType: FortuneColor,
     val jinxedColorType: FortuneColor
@@ -164,15 +169,19 @@ data class FortuneResponse(
                 fortuneDetail = dailyFortune.fortuneDetail,
                 jinxedColor = dailyFortune.jinxedColor,
                 jinxedColorHex = dailyFortune.jinxedColorHex,
+                jinxedColorImageUrl = ImageUrlMapper.Fortune.getJinxedColorImageUrl(),
                 jinxedMenu = dailyFortune.jinxedMenu,
+                jinxedMenuImageUrl = ImageUrlMapper.Fortune.getJinxedMenuImageUrl(),
                 jinxedNumber = dailyFortune.jinxedNumber,
                 jinxedColorType = dailyFortune.jinxedColorType,
                 positiveScore = dailyFortune.positiveScore,
                 negativeScore = dailyFortune.negativeScore,
                 todayMenu = dailyFortune.todayMenu,
+                todayMenuImageUrl = ImageUrlMapper.Fortune.getTodayMenuImageUrl(),
                 totalScore = dailyFortune.totalScore,
                 luckyColor = dailyFortune.luckyColor,
                 luckyColorHex = dailyFortune.luckyColorHex,
+                luckyColorImageUrl = ImageUrlMapper.Fortune.getLuckyColorImageUrl(),
                 luckyColorType = dailyFortune.luckyColorType,
                 luckyNumber = dailyFortune.luckyNumber
             )

--- a/src/main/kotlin/com/mashup/dhc/routes/Routes.kt
+++ b/src/main/kotlin/com/mashup/dhc/routes/Routes.kt
@@ -11,6 +11,7 @@ import com.mashup.dhc.domain.service.UserService
 import com.mashup.dhc.domain.service.isLeapYear
 import com.mashup.dhc.domain.service.now
 import com.mashup.dhc.external.NaverCloudPlatformObjectStorageAgent
+import com.mashup.dhc.utils.ImageUrlMapper
 import com.mashup.dhc.utils.Money
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.content.PartData
@@ -44,30 +45,30 @@ import kotlinx.io.readByteArray
 val generationAverageSpendMoney: Map<Generation, Map<Gender, Money>> =
     mapOf(
         Generation.TEENAGERS to
-                mapOf(
-                    Gender.MALE to Money(resolveSpendMoney(22000)),
-                    Gender.FEMALE to Money(resolveSpendMoney(31000))
-                ),
+            mapOf(
+                Gender.MALE to Money(resolveSpendMoney(22000)),
+                Gender.FEMALE to Money(resolveSpendMoney(31000))
+            ),
         Generation.TWENTIES to
-                mapOf(
-                    Gender.MALE to Money(resolveSpendMoney(64000)),
-                    Gender.FEMALE to Money(resolveSpendMoney(55000))
-                ),
+            mapOf(
+                Gender.MALE to Money(resolveSpendMoney(64000)),
+                Gender.FEMALE to Money(resolveSpendMoney(55000))
+            ),
         Generation.THIRTIES to
-                mapOf(
-                    Gender.MALE to Money(resolveSpendMoney(76000)),
-                    Gender.FEMALE to Money(resolveSpendMoney(62000))
-                ),
+            mapOf(
+                Gender.MALE to Money(resolveSpendMoney(76000)),
+                Gender.FEMALE to Money(resolveSpendMoney(62000))
+            ),
         Generation.FORTIES to
-                mapOf(
-                    Gender.MALE to Money(resolveSpendMoney(86000)),
-                    Gender.FEMALE to Money(resolveSpendMoney(72000))
-                ),
+            mapOf(
+                Gender.MALE to Money(resolveSpendMoney(86000)),
+                Gender.FEMALE to Money(resolveSpendMoney(72000))
+            ),
         Generation.UNKNOWN to
-                mapOf(
-                    Gender.MALE to Money(resolveSpendMoney(86000)),
-                    Gender.FEMALE to Money(resolveSpendMoney(72000))
-                )
+            mapOf(
+                Gender.MALE to Money(resolveSpendMoney(86000)),
+                Gender.FEMALE to Money(resolveSpendMoney(72000))
+            )
     )
 
 private fun resolveSpendMoney(value: Int): Int =
@@ -316,10 +317,7 @@ private fun User.resolveAnimalCard(): AnimalCard {
 private fun generateAnimalCardImageUrl(
     color: COLOR,
     animal: ANIMAL
-): String {
-    val baseUrl = "https://kr.object.ncloudstorage.com/dhc-object-storage/logos"
-    return "$baseUrl/${color.englishName}_${animal.englishName}.svg"
-}
+): String = ImageUrlMapper.getAnimalCardImageUrl(color, animal)
 
 private fun Route.logout(userService: UserService) {
     delete("/{userId}") {
@@ -428,7 +426,7 @@ private fun Route.calendarView(userService: UserService) {
                         .filter { it.missions.isNotEmpty() }
                         .sumOf {
                             100 * it.missions.filter { mission -> mission.finished }.size /
-                                    (it.missions.size)
+                                (it.missions.size)
                         }
 
                 val calendarDayMissionViews =

--- a/src/main/kotlin/com/mashup/dhc/routes/Routes.kt
+++ b/src/main/kotlin/com/mashup/dhc/routes/Routes.kt
@@ -44,30 +44,30 @@ import kotlinx.io.readByteArray
 val generationAverageSpendMoney: Map<Generation, Map<Gender, Money>> =
     mapOf(
         Generation.TEENAGERS to
-            mapOf(
-                Gender.MALE to Money(resolveSpendMoney(22000)),
-                Gender.FEMALE to Money(resolveSpendMoney(31000))
-            ),
+                mapOf(
+                    Gender.MALE to Money(resolveSpendMoney(22000)),
+                    Gender.FEMALE to Money(resolveSpendMoney(31000))
+                ),
         Generation.TWENTIES to
-            mapOf(
-                Gender.MALE to Money(resolveSpendMoney(64000)),
-                Gender.FEMALE to Money(resolveSpendMoney(55000))
-            ),
+                mapOf(
+                    Gender.MALE to Money(resolveSpendMoney(64000)),
+                    Gender.FEMALE to Money(resolveSpendMoney(55000))
+                ),
         Generation.THIRTIES to
-            mapOf(
-                Gender.MALE to Money(resolveSpendMoney(76000)),
-                Gender.FEMALE to Money(resolveSpendMoney(62000))
-            ),
+                mapOf(
+                    Gender.MALE to Money(resolveSpendMoney(76000)),
+                    Gender.FEMALE to Money(resolveSpendMoney(62000))
+                ),
         Generation.FORTIES to
-            mapOf(
-                Gender.MALE to Money(resolveSpendMoney(86000)),
-                Gender.FEMALE to Money(resolveSpendMoney(72000))
-            ),
+                mapOf(
+                    Gender.MALE to Money(resolveSpendMoney(86000)),
+                    Gender.FEMALE to Money(resolveSpendMoney(72000))
+                ),
         Generation.UNKNOWN to
-            mapOf(
-                Gender.MALE to Money(resolveSpendMoney(86000)),
-                Gender.FEMALE to Money(resolveSpendMoney(72000))
-            )
+                mapOf(
+                    Gender.MALE to Money(resolveSpendMoney(86000)),
+                    Gender.FEMALE to Money(resolveSpendMoney(72000))
+                )
     )
 
 private fun resolveSpendMoney(value: Int): Int =
@@ -305,13 +305,20 @@ private fun User.resolveAnimalCard(): AnimalCard {
     val daysFromEpoch = (nowDays - epochStart).days
 
     val middle = COLOR.entries[daysFromEpoch % COLOR.entries.size]
-
     val last = ANIMAL.entries[daysFromEpoch % ANIMAL.entries.size]
 
     return AnimalCard(
         name = "${first.description}의 ${middle.description} ${last.description}",
-        cardImageUrl = ""
+        cardImageUrl = generateAnimalCardImageUrl(middle, last)
     )
+}
+
+private fun generateAnimalCardImageUrl(
+    color: COLOR,
+    animal: ANIMAL
+): String {
+    val baseUrl = "https://kr.object.ncloudstorage.com/dhc-object-storage/logos"
+    return "$baseUrl/${color.englishName}_${animal.englishName}.svg"
 }
 
 private fun Route.logout(userService: UserService) {
@@ -333,30 +340,32 @@ enum class SEASON(
 }
 
 enum class COLOR(
-    val description: String
+    val description: String,
+    val englishName: String
 ) {
-    GREEN("초록"),
-    RED("붉은"),
-    YELLOW("노란"),
-    WHITE("흰"),
-    BLACK("검정")
+    GREEN("초록", "Green"),
+    RED("붉은", "Red"),
+    YELLOW("노란", "Yellow"),
+    WHITE("흰", "White"),
+    BLACK("검정", "Black")
 }
 
 enum class ANIMAL(
-    val description: String
+    val description: String,
+    val englishName: String
 ) {
-    MOUSE("쥐"),
-    COW("소"),
-    TIGER("호랑이"),
-    RABBIT("토끼"),
-    DRAGON("용"),
-    SNAKE("뱀"),
-    HORSE("말"),
-    SHEEP("양"),
-    MONKEY("원숭이"),
-    ROOSTER("닭"),
-    DOG("개"),
-    PIG("돼지")
+    MOUSE("쥐", "Mouse"),
+    COW("소", "Meet"),
+    TIGER("호랑이", "Tiger"),
+    RABBIT("토끼", "Rabbit"),
+    DRAGON("용", "Dragon"),
+    SNAKE("뱀", "Snake"),
+    HORSE("말", "Horse"),
+    SHEEP("양", "Sheep"),
+    MONKEY("원숭이", "Monkey"),
+    ROOSTER("닭", "Chicken"),
+    DOG("개", "Dog"),
+    PIG("돼지", "Pig")
 }
 
 private fun Route.analysisView(userService: UserService) {
@@ -419,7 +428,7 @@ private fun Route.calendarView(userService: UserService) {
                         .filter { it.missions.isNotEmpty() }
                         .sumOf {
                             100 * it.missions.filter { mission -> mission.finished }.size /
-                                (it.missions.size)
+                                    (it.missions.size)
                         }
 
                 val calendarDayMissionViews =

--- a/src/main/kotlin/com/mashup/dhc/utils/ImageUrlMapper.kt
+++ b/src/main/kotlin/com/mashup/dhc/utils/ImageUrlMapper.kt
@@ -1,0 +1,47 @@
+package com.mashup.dhc.utils
+
+import com.mashup.dhc.routes.ANIMAL
+import com.mashup.dhc.routes.COLOR
+
+object ImageUrlMapper {
+    private const val BASE_URL = "https://kr.object.ncloudstorage.com/dhc-object-storage"
+
+
+    /**
+     * 미션 카테고리 이미지 URL
+     */
+    object MissionCategory {
+        fun getTransportationImageUrl(): String = "$BASE_URL/logos/transportaion.png"
+
+        fun getFoodImageUrl(): String = "$BASE_URL/logos/food.png"
+
+        fun getDigitalImageUrl(): String = "$BASE_URL/logos/digital.png"
+
+        fun getShoppingImageUrl(): String = "$BASE_URL/logos/shopping.png"
+
+        fun getHobbyImageUrl(): String = "$BASE_URL/logos/hobby.png"
+
+        fun getFriendImageUrl(): String = "$BASE_URL/logos/friend.png"
+    }
+
+    /**
+     * 동물 카드 이미지 URL
+     */
+    fun getAnimalCardImageUrl(
+        color: COLOR,
+        animal: ANIMAL
+    ): String = "$BASE_URL/logos/${color.englishName}_${animal.englishName}.svg"
+
+    /**
+     * 운세 상세 이미지 URL
+     */
+    object Fortune {
+        fun getJinxedColorImageUrl(): String = "$BASE_URL/fortune-detail/jinxedColor.svg"
+
+        fun getJinxedMenuImageUrl(): String = "$BASE_URL/fortune-detail/jinxedMenu.svg"
+
+        fun getLuckyColorImageUrl(): String = "$BASE_URL/fortune-detail/luckyColor.svg"
+
+        fun getTodayMenuImageUrl(): String = "$BASE_URL/fortune-detail/todayMenu.svg"
+    }
+}

--- a/src/main/kotlin/com/mashup/dhc/utils/ImageUrlMapper.kt
+++ b/src/main/kotlin/com/mashup/dhc/utils/ImageUrlMapper.kt
@@ -6,7 +6,6 @@ import com.mashup.dhc.routes.COLOR
 object ImageUrlMapper {
     private const val BASE_URL = "https://kr.object.ncloudstorage.com/dhc-object-storage"
 
-
     /**
      * 미션 카테고리 이미지 URL
      */


### PR DESCRIPTION
## 관련 이슈

<!-- 연관된 이슈 번호가 있다면 태그 -->

NONE

---

## 변경 내용

- 마이페이지 내 동물 이미지 URL, 금전운 상세 내 행운의 요소 이미지 URL 추가
- 이미지 관리포인트 단일화 (`ImageUrlMapper.kt`)

---

## 체크리스트

- [x] Ktlint
- [x] 테스트 통과 여부
