### PR TITLE
`IndexOutOfRange` 오류 픽스

### DIFF
--- a/src/main/kotlin/com/mashup/dhc/routes/Routes.kt
+++ b/src/main/kotlin/com/mashup/dhc/routes/Routes.kt
@@ -28,6 +28,7 @@ import io.ktor.server.routing.post
 import io.ktor.server.routing.put
 import io.ktor.server.routing.route
 import java.math.BigDecimal
+import kotlin.math.abs
 import kotlinx.datetime.Clock
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.Instant
@@ -198,7 +199,7 @@ private fun Route.home(
             HomeViewResponse(
                 longTermMission = user.longTermMission?.let { MissionResponse.from(it) },
                 todayDailyMissionList = user.todayDailyMissionList.map { MissionResponse.from(it) },
-                todayDailyFortune = todayDailyFortune?.let { FortuneResponse.from(it) }, // FortuneResponse로 변환
+                todayDailyFortune = todayDailyFortune.let { FortuneResponse.from(it) }, // FortuneResponse로 변환
                 todayDone = todayPastRoutines.isNotEmpty()
             )
         )
@@ -361,7 +362,7 @@ private fun User.resolveAnimalCard(format: ImageFormat = ImageFormat.SVG): Anima
             .date
     val nowDays = this.birthDate.date
 
-    val daysFromEpoch = (nowDays - epochStart).days
+    val daysFromEpoch = abs((nowDays - epochStart).days)
 
     val middle = COLOR.entries[daysFromEpoch % COLOR.entries.size]
     val last = ANIMAL.entries[daysFromEpoch % ANIMAL.entries.size]


### PR DESCRIPTION
## 관련 이슈

<!-- 연관된 이슈 번호가 있다면 태그 -->

---

## 변경 내용

<!-- 변경 사항에 대한 설명 -->
- 인덱스 산식에 절댓값 연산이 없어, EnumEntries에서 찾을 때 `IndexOutOfRange`가 발생 -> 절댓값 연산 적용해 픽스

---

## 체크리스트

- [x] Ktlint
- [x] 테스트 통과 여부
