### PR TITLE
fix: MongoDB connectionString 환경변수 사용하도록 수정

### DIFF
--- a/src/main/kotlin/com/mashup/dhc/plugins/Dependencies.kt
+++ b/src/main/kotlin/com/mashup/dhc/plugins/Dependencies.kt
@@ -102,9 +102,17 @@ private data class MongoConfig(
 )
 
 private fun Application.getMongoConfig(): MongoConfig {
-    val host = environment.config.tryGetString("db.mongo.host") ?: "211.188.52.240"
-    val port = environment.config.tryGetString("db.mongo.port") ?: "27017"
+    // connectionString 환경변수 우선 사용
+    val connectionString = environment.config.tryGetString("db.mongo.connectionString")
     val databaseName = environment.config.tryGetString("db.mongo.database.name") ?: "dhc"
+
+    if (connectionString != null) {
+        return MongoConfig(connectionString, databaseName)
+    }
+
+    // fallback: host/port 방식
+    val host = environment.config.tryGetString("db.mongo.host") ?: "localhost"
+    val port = environment.config.tryGetString("db.mongo.port") ?: "27017"
 
     return MongoConfig("mongodb://$host:$port", databaseName)
 }

--- a/terraform/modules/security_list/main.tf
+++ b/terraform/modules/security_list/main.tf
@@ -69,6 +69,19 @@ resource "oci_core_security_list" "server" {
     }
   }
 
+  # MongoDB 내부 접근 허용 (VCN 내부에서만)
+  ingress_security_rules {
+    protocol    = "6" # TCP
+    source      = "192.168.1.0/24"
+    source_type = "CIDR_BLOCK"
+    description = "MongoDB 내부 접근"
+
+    tcp_options {
+      min = 27017
+      max = 27017
+    }
+  }
+
   # 모든 아웃바운드 트래픽 허용
   egress_security_rules {
     protocol         = "all"


### PR DESCRIPTION
## Summary
- `Dependencies.kt`: `connectionString` 환경변수 우선 사용하도록 수정
- `Security List`: VCN 내부 MongoDB 포트(27017) 통신 허용

## 문제
- 기존 코드는 `db.mongo.host`/`port`를 읽지만, `application.yaml`에는 `connectionString`만 정의됨
- 결과적으로 기본값(이전 NCP IP)으로 연결 시도

## 해결
- `connectionString` 환경변수가 있으면 우선 사용
- 없으면 `host`/`port` fallback

## Test plan
- [ ] 앱 재배포 후 MongoDB 연결 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)