### PR TITLE
feat: Home API에 미션 상태 필드 추가

### DIFF
--- a/src/main/kotlin/com/mashup/dhc/domain/model/User.kt
+++ b/src/main/kotlin/com/mashup/dhc/domain/model/User.kt
@@ -12,6 +12,7 @@ import com.mongodb.kotlin.client.coroutine.ClientSession
 import com.mongodb.kotlin.client.coroutine.MongoDatabase
 import java.math.BigDecimal
 import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.datetime.LocalDate
 import kotlinx.serialization.Transient
 import org.bson.BsonValue
 import org.bson.codecs.pojo.annotations.BsonId
@@ -31,6 +32,7 @@ data class User(
     val dailyFortunes: List<DailyFortune>? = listOf(),
     val currentAmulet: Amulet? = null,
     val totalSavedMoney: Money = Money(BigDecimal.ZERO),
+    val lastAccessDate: LocalDate? = null,
     @Transient val deleted: Boolean = false
 ) {
     private val age: Int
@@ -141,6 +143,24 @@ class UserRepository(
             return result.modifiedCount
         } catch (e: MongoException) {
             System.err.println("Unable to update due to an error: $e")
+        }
+        return 0
+    }
+
+    suspend fun updateLastAccessDate(
+        objectId: ObjectId,
+        date: LocalDate
+    ): Long {
+        try {
+            val query = Filters.eq("_id", objectId)
+            val updates = Updates.set(User::lastAccessDate.name, date)
+            val result =
+                mongoDatabase
+                    .getCollection<User>(USER_COLLECTION)
+                    .updateOne(query, updates)
+            return result.modifiedCount
+        } catch (e: MongoException) {
+            System.err.println("Unable to update lastAccessDate: $e")
         }
         return 0
     }

--- a/src/main/kotlin/com/mashup/dhc/domain/service/UserService.kt
+++ b/src/main/kotlin/com/mashup/dhc/domain/service/UserService.kt
@@ -276,6 +276,22 @@ class UserService(
         date: LocalDate
     ) = getPastRoutineMissionHistoriesBetween(userId, date, date)
 
+    suspend fun getYesterdayPastRoutines(
+        userId: String,
+        date: LocalDate
+    ) = getPastRoutineMissionHistoriesBetween(
+        userId,
+        date.minus(1, DateTimeUnit.DAY),
+        date.minus(1, DateTimeUnit.DAY)
+    )
+
+    suspend fun updateLastAccessDate(
+        userId: String,
+        date: LocalDate
+    ) {
+        userRepository.updateLastAccessDate(ObjectId(userId), date)
+    }
+
     suspend fun getWeekPastRoutines(
         userId: String,
         date: LocalDate

--- a/src/main/kotlin/com/mashup/dhc/routes/Response.kt
+++ b/src/main/kotlin/com/mashup/dhc/routes/Response.kt
@@ -33,7 +33,9 @@ data class HomeViewResponse(
     val longTermMission: MissionResponse?,
     val todayDailyMissionList: List<MissionResponse>,
     val todayDailyFortune: FortuneResponse?,
-    val todayDone: Boolean
+    val todayDone: Boolean,
+    val yesterdayMissionSuccess: Boolean,
+    val longAbsence: Boolean
 )
 
 @Serializable


### PR DESCRIPTION
## Summary
- `yesterdayMissionSuccess`: 어제 일일 미션(DAILY) 성공 여부
- `longAbsence`: 2일 이상 미접속 여부
- User 엔티티에 `lastAccessDate` 필드 추가
- `/home` API 호출 시 `lastAccessDate` 자동 업데이트

## 비즈니스 로직
| 상황 | yesterdayMissionSuccess | longAbsence |
|------|------------------------|-------------|
| 어제 접속, 미션 성공 | true | false |
| 어제 접속, 미션 실패 | false | false |
| 2일 이상 미접속 | false | true |

## 변경 파일
- `User.kt`: `lastAccessDate` 필드 및 `updateLastAccessDate()` 메서드 추가
- `UserService.kt`: `updateLastAccessDate()` 메서드 추가
- `Response.kt`: `HomeViewResponse`에 새 필드 추가
- `Routes.kt`: `/home` 엔드포인트 로직 수정

## Test plan
- [ ] `/view/users/{userId}/home` API 호출 시 `yesterdayMissionSuccess`, `longAbsence` 필드 확인
- [ ] 2일 이상 미접속 후 접속 시 `longAbsence = true` 확인
- [ ] 어제 미션 성공 후 접속 시 `yesterdayMissionSuccess = true` 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)