### PR TITLE
feat: Home API에 isFirstAccess 필드 추가

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "enabledPlugins": {
+    "kotlin-lsp@claude-plugins-official": true
+  }
+}

--- a/src/main/kotlin/com/mashup/dhc/routes/Response.kt
+++ b/src/main/kotlin/com/mashup/dhc/routes/Response.kt
@@ -35,7 +35,8 @@ data class HomeViewResponse(
     val todayDailyFortune: FortuneResponse?,
     val todayDone: Boolean,
     val yesterdayMissionSuccess: Boolean,
-    val longAbsence: Boolean
+    val longAbsence: Boolean,
+    val isFirstAccess: Boolean
 )
 
 @Serializable

--- a/src/main/kotlin/com/mashup/dhc/routes/Routes.kt
+++ b/src/main/kotlin/com/mashup/dhc/routes/Routes.kt
@@ -260,13 +260,14 @@ private fun Route.home(
                 .toLocalDateTime(TimeZone.currentSystemDefault())
                 .date
 
-        // 2일 이상 미접속 여부 계산 (lastAccessDate 업데이트 전에 계산)
+        // 2일 이상 미접속 여부 및 첫 접속 여부 계산 (lastAccessDate 업데이트 전에 계산)
         val lastAccess = user.lastAccessDate
+        val isFirstAccess = lastAccess == null
         val daysSinceLastAccess =
             if (lastAccess != null) {
                 (now.toEpochDays() - lastAccess.toEpochDays()).toInt()
             } else {
-                0 // 첫 접속 또는 기존 사용자
+                0 // 첫 접속
             }
         val longAbsence = daysSinceLastAccess >= 2
 
@@ -311,7 +312,8 @@ private fun Route.home(
                 todayDailyFortune = todayDailyFortune.let { FortuneResponse.from(it) },
                 todayDone = todayPastRoutines.isNotEmpty(),
                 yesterdayMissionSuccess = yesterdayMissionSuccess,
-                longAbsence = longAbsence
+                longAbsence = longAbsence,
+                isFirstAccess = isFirstAccess
             )
         )
     }

--- a/src/main/resources/openapi/documentation.yaml
+++ b/src/main/resources/openapi/documentation.yaml
@@ -449,6 +449,7 @@ paths:
                 todayDone: false
                 yesterdayMissionSuccess: true
                 longAbsence: false
+                isFirstAccess: false
 
   /view/users/{userId}/myPage:
     get:
@@ -878,6 +879,10 @@ components:
         longAbsence:
           type: boolean
           description: "Whether user has been absent for 2 or more days"
+          example: false
+        isFirstAccess:
+          type: boolean
+          description: "Whether this is user's first access (lastAccessDate was null)"
           example: false
 
     MissionCategoriesResponse:


### PR DESCRIPTION
## Summary
- 처음 접속 여부를 구분하기 위한 `isFirstAccess` 필드 추가
- `lastAccessDate`가 null이면 `isFirstAccess = true`
- 신규 사용자와 미션 실패 케이스를 구분 가능

## 비즈니스 로직

| 상황 | A (yesterdayMissionSuccess) | B (longAbsence) | C (isFirstAccess) | 메시지 |
|------|---|---|---|--------|
| 첫 접속 | false | false | **true** | 환영 메시지 |
| 어제 접속, 미션 성공 | true | false | false | 없음 |
| 어제 접속, 미션 실패 | false | false | false | 미션 실패 메시지 |
| 2일 이상 미접속 | false | true | false | 오랜만 메시지 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)