### PR TITLE
feat: 포인트 시스템 추가 및 러브미션 todayDailyMissionList 통합

### DIFF
--- a/src/main/kotlin/com/mashup/dhc/domain/model/Mission.kt
+++ b/src/main/kotlin/com/mashup/dhc/domain/model/Mission.kt
@@ -57,6 +57,19 @@ enum class MissionType {
     LOVE
 }
 
+/**
+ * 난이도별 포인트 계산
+ * - Easy (difficulty 1): 50pt
+ * - Medium (difficulty 2): 100pt
+ * - Hard (difficulty 3+): 200pt
+ */
+fun Mission.calculatePoint(): Long =
+    when (difficulty) {
+        1 -> 50L
+        2 -> 100L
+        else -> 200L
+    }
+
 class MissionRepository(
     private val mongoDatabase: MongoDatabase
 ) {

--- a/src/main/kotlin/com/mashup/dhc/domain/model/User.kt
+++ b/src/main/kotlin/com/mashup/dhc/domain/model/User.kt
@@ -32,6 +32,7 @@ data class User(
     val dailyFortunes: List<DailyFortune>? = listOf(),
     val currentAmulet: Amulet? = null,
     val totalSavedMoney: Money = Money(BigDecimal.ZERO),
+    val point: Long = 0L,
     val lastAccessDate: LocalDate? = null,
     val loveMissionStatus: LoveMissionStatus? = null,
     @Transient val deleted: Boolean = false
@@ -180,6 +181,24 @@ class UserRepository(
             return result.modifiedCount
         } catch (e: MongoException) {
             System.err.println("Unable to update loveMissionStatus: $e")
+        }
+        return 0
+    }
+
+    suspend fun addPoint(
+        objectId: ObjectId,
+        pointToAdd: Long
+    ): Long {
+        try {
+            val query = Filters.eq("_id", objectId)
+            val updates = Updates.inc(User::point.name, pointToAdd)
+            val result =
+                mongoDatabase
+                    .getCollection<User>(USER_COLLECTION)
+                    .updateOne(query, updates)
+            return result.modifiedCount
+        } catch (e: MongoException) {
+            System.err.println("Unable to add point: $e")
         }
         return 0
     }

--- a/src/main/kotlin/com/mashup/dhc/domain/service/LoveMissionService.kt
+++ b/src/main/kotlin/com/mashup/dhc/domain/service/LoveMissionService.kt
@@ -12,10 +12,8 @@ import kotlinx.datetime.LocalDate
 import org.bson.types.ObjectId
 
 data class LoveMissionInfo(
-    val missionId: String,
+    val mission: Mission,
     val dayNumber: Int,
-    val title: String,
-    val finished: Boolean,
     val remainingDays: Int
 )
 
@@ -103,10 +101,8 @@ class LoveMissionService(
         val todayMission = status.getTodayMission(today) ?: return null
 
         return LoveMissionInfo(
-            missionId = todayMission.id.toString(),
+            mission = todayMission,
             dayNumber = dayNumber,
-            title = todayMission.title,
-            finished = todayMission.finished,
             remainingDays = status.remainingDays(today)
         )
     }

--- a/src/main/kotlin/com/mashup/dhc/domain/service/UserService.kt
+++ b/src/main/kotlin/com/mashup/dhc/domain/service/UserService.kt
@@ -292,6 +292,11 @@ class UserService(
         userRepository.updateLastAccessDate(ObjectId(userId), date)
     }
 
+    suspend fun addPoint(
+        userId: String,
+        pointToAdd: Long
+    ): Long = userRepository.addPoint(ObjectId(userId), pointToAdd)
+
     suspend fun getWeekPastRoutines(
         userId: String,
         date: LocalDate

--- a/src/main/kotlin/com/mashup/dhc/routes/Response.kt
+++ b/src/main/kotlin/com/mashup/dhc/routes/Response.kt
@@ -37,7 +37,7 @@ data class HomeViewResponse(
     val yesterdayMissionSuccess: Boolean,
     val longAbsence: Boolean,
     val isFirstAccess: Boolean,
-    val loveMission: LoveMissionResponse? = null
+    val point: Long
 )
 
 @Serializable
@@ -85,7 +85,9 @@ data class MissionResponse(
     val cost: Money,
     val endDate: LocalDate?,
     val title: String,
-    val switchCount: Int
+    val switchCount: Int,
+    val dayNumber: Int? = null,
+    val remainingDays: Int? = null
 ) {
     companion object {
         fun from(mission: Mission): MissionResponse =
@@ -99,6 +101,25 @@ data class MissionResponse(
                 endDate = mission.endDate,
                 title = mission.title,
                 switchCount = mission.switchCount
+            )
+
+        fun fromLoveMission(
+            mission: Mission,
+            dayNumber: Int,
+            remainingDays: Int
+        ): MissionResponse =
+            MissionResponse(
+                missionId = mission.id.toString(),
+                category = mission.category.displayName,
+                difficulty = mission.difficulty,
+                type = mission.type,
+                finished = mission.finished,
+                cost = mission.cost,
+                endDate = mission.endDate,
+                title = mission.title,
+                switchCount = mission.switchCount,
+                dayNumber = dayNumber,
+                remainingDays = remainingDays
             )
     }
 }

--- a/src/main/resources/openapi/documentation.yaml
+++ b/src/main/resources/openapi/documentation.yaml
@@ -75,7 +75,7 @@ paths:
   /api/users/{userId}/missions/{missionId}:
     put:
       summary: "Change Mission Status"
-      description: "Change the completion status of a specific mission for a user or switch to a new mission. This API also supports love missions - use the missionId from loveMission in HomeViewResponse. Note: Love missions only support 'finished' action (switch is not available)."
+      description: "Change the completion status of a specific mission for a user or switch to a new mission. This API also supports love missions (type=LOVE in todayDailyMissionList). Note: Love missions only support 'finished' action (switch is not available). When a mission is completed (finished=true), points are awarded based on difficulty: Easy(1)=50pt, Medium(2)=100pt, Hard(3+)=200pt."
       parameters:
         - name: userId
           in: path
@@ -419,6 +419,17 @@ paths:
                   title: "여행 가기 위해 돈 모으기"
                   switchCount: 0
                 todayDailyMissionList:
+                  - missionId: "507f1f77bcf86cd799439066"
+                    category: "사교·모임"
+                    difficulty: 2
+                    type: "LOVE"
+                    finished: false
+                    cost: "0.00"
+                    endDate: "2024-01-15"
+                    title: "상대방에게 좋아하는 점 3가지 말하기"
+                    switchCount: 0
+                    dayNumber: 1
+                    remainingDays: 13
                   - missionId: "507f1f77bcf86cd799439044"
                     category: "식음료"
                     difficulty: 2
@@ -450,12 +461,7 @@ paths:
                 yesterdayMissionSuccess: true
                 longAbsence: false
                 isFirstAccess: false
-                loveMission:
-                  missionId: "507f1f77bcf86cd799439066"
-                  dayNumber: 1
-                  title: "상대방에게 좋아하는 점 3가지 말하기"
-                  finished: false
-                  remainingDays: 13
+                point: 150
 
   /view/users/{userId}/myPage:
     get:
@@ -934,7 +940,7 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Mission"
-          description: "List of today's daily missions"
+          description: "List of today's missions including love mission (if active) at the top. Love missions have type=LOVE and include dayNumber, remainingDays fields."
         todayDailyFortune:
           $ref: "#/components/schemas/FortuneResponse"
           nullable: true
@@ -954,10 +960,11 @@ components:
           type: boolean
           description: "Whether this is user's first access (lastAccessDate was null)"
           example: false
-        loveMission:
-          $ref: "#/components/schemas/LoveMissionResponse"
-          nullable: true
-          description: "Today's love mission (if active)"
+        point:
+          type: integer
+          format: int64
+          description: "User's total accumulated points"
+          example: 150
 
     MissionCategoriesResponse:
       type: object
@@ -1105,7 +1112,7 @@ components:
           type: integer
           minimum: 1
           maximum: 5
-          description: "Mission difficulty level"
+          description: "Mission difficulty level (1=Easy: 50pt, 2=Medium: 100pt, 3+=Hard: 200pt)"
           example: 3
         type:
           $ref: "#/components/schemas/MissionType"
@@ -1131,6 +1138,18 @@ components:
           type: integer
           description: "Number of times mission has been switched"
           example: 0
+        dayNumber:
+          type: integer
+          minimum: 1
+          maximum: 14
+          description: "Love mission day number (1-14). Only present for LOVE type missions."
+          example: 1
+          nullable: true
+        remainingDays:
+          type: integer
+          description: "Number of remaining days for love mission. Only present for LOVE type missions."
+          example: 13
+          nullable: true
 
     DailyFortune:
       type: object
@@ -1248,7 +1267,8 @@ components:
       enum:
         - LONG_TERM
         - DAILY
-      description: "Mission type"
+        - LOVE
+      description: "Mission type. LOVE missions appear at the top of todayDailyMissionList and have additional dayNumber, remainingDays fields."
       example: "DAILY"
 
     UploadResponse:
@@ -1723,34 +1743,3 @@ components:
           example: "Share completed successfully"
           nullable: true
 
-    LoveMissionResponse:
-      type: object
-      required:
-        - missionId
-        - dayNumber
-        - title
-        - finished
-        - remainingDays
-      properties:
-        missionId:
-          type: string
-          description: "Mission ID (can be used with existing mission API)"
-          example: "507f1f77bcf86cd799439066"
-        dayNumber:
-          type: integer
-          minimum: 1
-          maximum: 14
-          description: "Current love mission day number (1-14)"
-          example: 1
-        title:
-          type: string
-          description: "Love mission title"
-          example: "상대방에게 좋아하는 점 3가지 말하기"
-        finished:
-          type: boolean
-          description: "Whether today's love mission is completed"
-          example: false
-        remainingDays:
-          type: integer
-          description: "Number of remaining days for love mission (including today)"
-          example: 13


### PR DESCRIPTION
## Summary
- User에 point 필드 추가 및 미션 완료 시 난이도별 포인트 적립
- 러브미션을 별도 필드 대신 todayDailyMissionList 맨 앞에 포함
- MissionResponse에 dayNumber, remainingDays 필드 추가 (러브미션용)

## Changes
### 포인트 시스템
- `User`에 `point: Long` 필드 추가
- `Mission.calculatePoint()` 함수 추가
  - Easy (difficulty 1): 50pt
  - Medium (difficulty 2): 100pt
  - Hard (difficulty 3+): 200pt
- 미션 완료 시 자동 포인트 적립 (일반 미션 + 러브미션 모두)
- Home API 응답에 `point` 필드 추가

### 러브미션 통합
- `HomeViewResponse`에서 별도 `loveMission` 필드 제거
- 러브미션을 `todayDailyMissionList` 맨 앞에 포함
- `MissionResponse`에 optional 필드 추가:
  - `dayNumber`: 러브미션 일차 (1-14)
  - `remainingDays`: 남은 일수
- 클라이언트는 `type: LOVE`로 러브미션 구분

## Test plan
- [ ] 미션 완료 시 포인트가 정상적으로 적립되는지 확인
- [ ] Home API에서 point 필드가 정상적으로 반환되는지 확인
- [ ] 러브미션이 todayDailyMissionList 맨 앞에 포함되는지 확인
- [ ] 러브미션에 dayNumber, remainingDays 필드가 포함되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)